### PR TITLE
models mandatory video_data field

### DIFF
--- a/djangocms_youtube/models.py
+++ b/djangocms_youtube/models.py
@@ -63,7 +63,7 @@ class Youtube(CMSPlugin):
     )
 
     video_data = JSONField(
-        verbose_name=_('YouTube Data'), blank=True, null=True,
+        verbose_name=_('YouTube Data'), 
         help_text=_('For advanced users only — please do not edit '
                     'this data unless you know what you are doing.')
     )


### PR DESCRIPTION
I had an issue with user just pasting url, e.g. https://www.youtube.com/watch?v=gDLKwTdurxg and then clicking "save" without anything else. It basically does not process the video and after save the plugin fails on:

```
Exception Value:    
type object argument after ** must be a mapping, not NoneType
Exception Location: /usr/lib/python2.7/site-packages/djangocms_youtube/models.py in video, line 76
```

Which really users `vide_data` as kwargs:

```
    @property
    def video(self):
        cls = Video(**self.video_data)
        return cls
```

It is enough for me to mark this field as mandatory. Probably updated migration is needed, but I have not idea how to do it here on GH.
